### PR TITLE
Fix QA issue

### DIFF
--- a/src/transport/forms.py
+++ b/src/transport/forms.py
@@ -50,7 +50,8 @@ class TransportForm(MRSRequestFormMixin, forms.ModelForm):
         if date_depart and date_return and date_depart > date_return:
             self.add_error(
                 'date_return',
-                "La date de retour doit être égale ou postérieure à la date aller",
+                'La date de retour doit être égale ou postérieure à la'
+                'date aller',
             )
 
         return cleaned_data


### PR DESCRIPTION
Respecte la limite à 80 caractères par ligne. Erreur remontée :
````
src/transport/forms.py:53:80: E501 line too long (83 > 79 characters)
                "La date de retour doit être égale ou postérieure à la date aller",
````